### PR TITLE
[fix] RadarAnalytics userId prop 추가 및 AI insights import 통일

### DIFF
--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, lazy, Suspense } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { Stethoscope, RefreshCw, AlertCircle, Home } from 'lucide-react';
 import { useTheme } from 'src/contexts/ThemeContext';
 import { ThemeSwitch } from 'src/components/common/ThemeToggle';
@@ -56,6 +56,8 @@ const metricAnalysis: Record<string, string> = {
 
 export default function UserPage() {
   const router = useRouter();
+  const params = useParams();
+  const userId = params?.userId as string;
   const [dataRefreshDate] = useState(new Date().toLocaleDateString());
   const { theme } = useTheme();
 
@@ -266,6 +268,7 @@ export default function UserPage() {
             avgMetrics={metricsData?.regionalAverageMetrics || regionalAverages.metrics}
             theme={theme}
             metricAnalysis={metricAnalysis}
+            userId={userId}
           />
         </div>
 

--- a/src/components/user-page/NurseDashboard/RadarAnalytics.tsx
+++ b/src/components/user-page/NurseDashboard/RadarAnalytics.tsx
@@ -13,13 +13,14 @@ import {
   Zap,
   Award
 } from 'lucide-react';
-import { useAllAiInsights } from 'src/api/useAiInsights';
+import { useAllAiInsights } from 'src/api/ai/useAiInsights';
 
 interface RadarAnalyticsProps {
   userMetrics: Record<string, number>;
   avgMetrics: Record<string, number>;
   theme: 'light' | 'dark';
   metricAnalysis: Record<string, string>;
+  userId?: string;
 }
 
 interface RadarPoint {
@@ -77,10 +78,11 @@ export default function RadarAnalytics({
   avgMetrics,
   theme,
   metricAnalysis,
+  userId,
 }: RadarAnalyticsProps) {
   const [hoveredMetric, setHoveredMetric] = useState<string | null>(null);
   const [selectedMetric, setSelectedMetric] = useState<string | null>(null);
-  const { data: allInsights, isLoading: isInsightsLoading } = useAllAiInsights();
+  const { data: allInsights, isLoading: isInsightsLoading } = useAllAiInsights(userId);
 
   // Memoized calculations for performance
   const maxRadius = 80; // Reduced to leave more space for labels
@@ -479,7 +481,7 @@ export default function RadarAnalytics({
                       : ' Consider focusing on areas marked in red for improvement.'}
                   </p>
                   
-                  {allInsights?.market && (
+                  {allInsights?.skillTransfer && (
                     <div className={`flex items-start gap-3 pt-2 pl-4 border-l-4 ${
                       theme === 'light' ? 'border-amber-300' : 'border-amber-600'
                     }`}>
@@ -487,7 +489,7 @@ export default function RadarAnalytics({
                       <span className={`text-sm sm:text-base ${
                         theme === 'light' ? 'text-gray-700' : 'text-gray-300'
                       }`}>
-                        {allInsights.market}
+                        {allInsights.skillTransfer}
                       </span>
                     </div>
                   )}

--- a/src/components/user-page/NurseDashboard/UserProfileCard.tsx
+++ b/src/components/user-page/NurseDashboard/UserProfileCard.tsx
@@ -13,7 +13,7 @@ import {
   ChevronRight
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { useAiInsight } from 'src/api/useAiInsights';
+import { useAiInsight } from 'src/api/ai/useAiInsights';
 import SimpleBeanHead, { 
   type SimpleBeanHeadConfig as BeanHeadConfig, 
   PRESET_STYLES
@@ -21,6 +21,7 @@ import SimpleBeanHead, {
 import CustomizeSectionUpdated from './CustomizeSectionUpdated';
 
 interface UserProfile {
+  id?: string;
   name: string;
   role: string;
   specialty: string;
@@ -41,7 +42,7 @@ export default function UserProfileCard({
   userProfile,
   theme,
 }: UserProfileCardProps) {
-  const { data: careerInsight, isLoading } = useAiInsight('career');
+  const { data: careerInsight, isLoading } = useAiInsight('nurse_summary', userProfile?.id);
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const [currentTab, setCurrentTab] = useState('preset');
   const [avatarConfig, setAvatarConfig] = useState<BeanHeadConfig>({
@@ -225,8 +226,8 @@ export default function UserProfileCard({
                         if (isLoading) {
                           return <span className="animate-pulse">Analyzing your career trajectory...</span>;
                         }
-                        if (careerInsight?.insight) {
-                          return careerInsight.insight;
+                        if (careerInsight?.content) {
+                          return careerInsight.content;
                         }
                         return "You're on track for a 3-5% salary increase. Consider trauma specialization for additional 8-12% market value.";
                       })()}


### PR DESCRIPTION
- RadarAnalytics에 userId prop 추가하여 AI insights 호출 가능하도록 수정
- useParams로 URL에서 userId 가져와서 전달
- 모든 컴포넌트에서 구 버전 AI insights import를 새 버전으로 통일
- UserProfile interface에 id 필드 추가
- AiInsight 타입 수정 (insight → content)

이제 모든 컴포넌트가 새로운 AI API를 사용합니다.
Mixed Content 문제는 AI API HTTPS 적용 후 해결 예정입니다.