### PR TITLE
fix: NEXT_PUBLIC_API_URL을 NEXT_PUBLIC_BE_URL로 통일

### DIFF
--- a/src/api/useDifferentialAPI.ts
+++ b/src/api/useDifferentialAPI.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+const API_BASE_URL = `${process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000'}/api`;
 
 // Types
 export interface DifferentialItem {

--- a/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
+++ b/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { AvatarConfig } from '../types';
 import { DEFAULT_AVATAR_CONFIG } from '../constants';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+const API_BASE_URL = `${process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000'}/api`;
 
 export function useAvatarManagement() {
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);


### PR DESCRIPTION
- useAvatarManagement.ts와 useDifferentialAPI.ts에서 사용하던 NEXT_PUBLIC_API_URL 환경변수를 다른 API들과 동일하게 NEXT_PUBLIC_BE_URL로 변경
- 이제 모든 API 호출이 동일한 환경변수를 사용하여 일관성 향상
- localhost:3000 하드코딩 문제 해결

