### PR TITLE
[fix] API 파일들이 공통 apiClient 사용하도록 수정

### DIFF
--- a/src/api/useCareerHistory.ts
+++ b/src/api/useCareerHistory.ts
@@ -1,18 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import { apiClient } from 'src/lib/axios';
 import toast from 'react-hot-toast';
-
-// API Base URL
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-// Axios instance with credentials
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
 
 export interface CareerHistoryItem {
   id: string;

--- a/src/api/useCareerProgression.ts
+++ b/src/api/useCareerProgression.ts
@@ -1,17 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-
-// API Base URL
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-// Axios instance with credentials
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
+import { apiClient } from 'src/lib/axios';
 
 interface CareerProgressionData {
   totalYears: number;

--- a/src/api/useDashboard.ts
+++ b/src/api/useDashboard.ts
@@ -1,17 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-
-// API Base URL
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-// Axios instance with credentials
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
+import { apiClient } from 'src/lib/axios';
 
 interface WageDistributionResponse {
   payDistributionData: Array<{

--- a/src/api/useDifferentials.ts
+++ b/src/api/useDifferentials.ts
@@ -1,15 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
+import { apiClient } from 'src/lib/axios';
 
 export interface DifferentialsSummary {
   hourlyRate: number;

--- a/src/api/useUserMetrics.ts
+++ b/src/api/useUserMetrics.ts
@@ -1,15 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
+import { apiClient } from 'src/lib/axios';
 
 export interface UserMetrics {
   pay: number;


### PR DESCRIPTION
- useCareerHistory.ts: 중복 axios 인스턴스 제거하고 공통 apiClient 사용
- useDashboard.ts: 중복 axios 인스턴스 제거하고 공통 apiClient 사용
- useCareerProgression.ts: 중복 axios 인스턴스 제거하고 공통 apiClient 사용
- useUserMetrics.ts: 중복 axios 인스턴스 제거하고 공통 apiClient 사용
- useDifferentials.ts: 중복 axios 인스턴스 제거하고 공통 apiClient 사용

모든 API 파일이 이제 src/lib/axios의 공통 apiClient를 사용합니다.