### PR TITLE
fix: implement Vercel Rewrites for mobile authentication

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,10 +11,13 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   async rewrites() {
+    // 프로덕션과 개발 환경 모두 지원
+    const backendUrl = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
+
     return [
       {
         source: '/api/:path*',
-        destination: 'http://localhost:3000/api/:path*',
+        destination: `${backendUrl}/api/:path*`,
       },
     ];
   },

--- a/src/api/Auth/useAuth.ts
+++ b/src/api/Auth/useAuth.ts
@@ -38,7 +38,7 @@ const useAuth = () => {
     setIsLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/signup`,
+        '/api/auth/signup',
         {
           method: 'POST',
           headers: {
@@ -84,7 +84,7 @@ const useAuth = () => {
     setIsLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/signin`,
+        '/api/auth/signin',
         {
           method: 'POST',
           headers: {
@@ -131,7 +131,7 @@ const useAuth = () => {
   const checkAuth = async (): Promise<User | null> => {
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/me`,
+        '/api/auth/me',
         {
           method: 'GET',
           credentials: 'include',

--- a/src/api/onboarding/useBasicInfoMutation.ts
+++ b/src/api/onboarding/useBasicInfoMutation.ts
@@ -19,7 +19,7 @@ const useBasicInfoMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/basic-info`,
+        '/api/onboarding/basic-info',
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useCompleteOnboarding.ts
+++ b/src/api/onboarding/useCompleteOnboarding.ts
@@ -27,7 +27,7 @@ const useCompleteOnboarding = () => {
 
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/complete`,
+        '/api/onboarding/complete',
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useCultureMutation.ts
+++ b/src/api/onboarding/useCultureMutation.ts
@@ -20,7 +20,7 @@ const useCultureMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/culture`,
+        '/api/onboarding/culture',
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useEmploymentMutation.ts
+++ b/src/api/onboarding/useEmploymentMutation.ts
@@ -34,7 +34,7 @@ const useEmploymentMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/employment`,
+        '/api/onboarding/employment',
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useInitializeOnboarding.ts
+++ b/src/api/onboarding/useInitializeOnboarding.ts
@@ -21,7 +21,7 @@ const checkExistingProgress = async (
   tempUserId: string
 ): Promise<OnboardingProgress | null> => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/progress/${tempUserId}`,
+    `/api/onboarding/progress/${tempUserId}`,
     {
       credentials: 'include',
     }
@@ -36,7 +36,7 @@ const checkExistingProgress = async (
 
 const createNewOnboarding = async () => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/init`,
+    '/api/onboarding/init',
     {
       method: 'POST',
       headers: {

--- a/src/api/useDifferentialAPI.ts
+++ b/src/api/useDifferentialAPI.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 
-const API_BASE_URL = `${process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000'}/api`;
+const API_BASE_URL = '/api';
 
 // Types
 export interface DifferentialItem {

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -28,9 +28,7 @@ export default function AuthCallback() {
 
         if (session) {
           // Sync with backend to create/update user in local database
-          const baseUrl = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-          
-          const response = await fetch(`${baseUrl}/api/auth/oauth/callback`, {
+          const response = await fetch('/api/auth/oauth/callback', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,8 +113,7 @@ export default function HomePage() {
       }
 
       // If user is logged in but hasn't completed onboarding, let them continue
-      const API_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-      const response = await fetch(`${API_URL}/api/onboarding/init`, {
+      const response = await fetch('/api/onboarding/init', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
+++ b/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { AvatarConfig } from '../types';
 import { DEFAULT_AVATAR_CONFIG } from '../constants';
 
-const API_BASE_URL = `${process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000'}/api`;
+const API_BASE_URL = '/api';
 
 export function useAvatarManagement() {
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);

--- a/src/hooks/useAuthStore.ts
+++ b/src/hooks/useAuthStore.ts
@@ -45,10 +45,7 @@ const useAuthStore = create<AuthState>()((set, get) => ({
         set({ isLoading: true });
         
         try {
-          const baseUrl =
-            process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-          const response = await fetch(`${baseUrl}/api/auth/me`, {
+          const response = await fetch('/api/auth/me', {
             method: 'GET',
             credentials: 'include',
           });
@@ -105,10 +102,7 @@ const useAuthStore = create<AuthState>()((set, get) => ({
 
       signOut: async () => {
         try {
-          const baseUrl =
-            process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
-
-          const response = await fetch(`${baseUrl}/api/auth/signout`, {
+          const response = await fetch('/api/auth/signout', {
             method: 'POST',
             credentials: 'include',
           });

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,7 +2,8 @@ import type { AxiosError } from 'axios';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3000';
+// Vercel Rewrites를 사용하므로 상대 경로 사용
+const API_BASE_URL = '';
 
 // 공통 axios 인스턴스 생성
 export const apiClient = axios.create({

--- a/src/store/onboardingStores.ts
+++ b/src/store/onboardingStores.ts
@@ -159,7 +159,7 @@ const useOnboardingStore = create<OnboardingStore>((set, get) => ({
 
       // 서버에서 진행상황 조회
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/progress?tempUserId=${tempUserId}`,
+        `/api/onboarding/progress?tempUserId=${tempUserId}`,
         {
           method: 'GET',
           credentials: 'include',


### PR DESCRIPTION
- Configure Vercel Rewrites to proxy API calls through same domain
- Update all API endpoints to use relative paths instead of absolute URLs
- Remove process.env.NEXT_PUBLIC_BE_URL from client-side code
- Fix Safari mobile cookie blocking issue with cross-domain requests

This resolves the authentication issue on mobile browsers where third-party cookies are blocked by default (especially Safari).

🤖 Generated with [Claude Code](https://claude.ai/code)