### PR TITLE
[fix] Restore original absolute API URLs

### DIFF
--- a/src/api/Auth/useAuth.ts
+++ b/src/api/Auth/useAuth.ts
@@ -38,7 +38,7 @@ const useAuth = () => {
     setIsLoading(true);
     try {
       const response = await fetch(
-        '/api/auth/signup',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/signup`,
         {
           method: 'POST',
           headers: {
@@ -84,7 +84,7 @@ const useAuth = () => {
     setIsLoading(true);
     try {
       const response = await fetch(
-        '/api/auth/signin',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/signin`,
         {
           method: 'POST',
           headers: {
@@ -131,7 +131,7 @@ const useAuth = () => {
   const checkAuth = async (): Promise<User | null> => {
     try {
       const response = await fetch(
-        '/api/auth/me',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/auth/me`,
         {
           method: 'GET',
           credentials: 'include',

--- a/src/api/onboarding/useBasicInfoMutation.ts
+++ b/src/api/onboarding/useBasicInfoMutation.ts
@@ -19,7 +19,7 @@ const useBasicInfoMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        '/api/onboarding/basic-info',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/basic-info`,
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useCompleteOnboarding.ts
+++ b/src/api/onboarding/useCompleteOnboarding.ts
@@ -27,7 +27,7 @@ const useCompleteOnboarding = () => {
 
     try {
       const response = await fetch(
-        '/api/onboarding/complete',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/complete`,
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useCultureMutation.ts
+++ b/src/api/onboarding/useCultureMutation.ts
@@ -20,7 +20,7 @@ const useCultureMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        '/api/onboarding/culture',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/culture`,
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useEmploymentMutation.ts
+++ b/src/api/onboarding/useEmploymentMutation.ts
@@ -34,7 +34,7 @@ const useEmploymentMutation = () => {
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
       const response = await fetch(
-        '/api/onboarding/employment',
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/employment`,
         {
           method: 'POST',
           headers: {

--- a/src/api/onboarding/useInitializeOnboarding.ts
+++ b/src/api/onboarding/useInitializeOnboarding.ts
@@ -21,7 +21,7 @@ const checkExistingProgress = async (
   tempUserId: string
 ): Promise<OnboardingProgress | null> => {
   const response = await fetch(
-    `/api/onboarding/progress/${tempUserId}`,
+    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/progress/${tempUserId}`,
     {
       credentials: 'include',
     }
@@ -36,7 +36,7 @@ const checkExistingProgress = async (
 
 const createNewOnboarding = async () => {
   const response = await fetch(
-    '/api/onboarding/init',
+    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/init`,
     {
       method: 'POST',
       headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,7 +113,7 @@ export default function HomePage() {
       }
 
       // If user is logged in but hasn't completed onboarding, let them continue
-      const response = await fetch('/api/onboarding/init', {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/init`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
+++ b/src/components/features/dashboard/UserProfileCard/hooks/useAvatarManagement.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { AvatarConfig } from '../types';
 import { DEFAULT_AVATAR_CONFIG } from '../constants';
 
-const API_BASE_URL = '/api';
+const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'https://nurse-backend.duckdns.org';
 
 export function useAvatarManagement() {
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);

--- a/src/hooks/useAuthStore.ts
+++ b/src/hooks/useAuthStore.ts
@@ -45,7 +45,7 @@ const useAuthStore = create<AuthState>()((set, get) => ({
         set({ isLoading: true });
         
         try {
-          const response = await fetch('/api/auth/me', {
+          const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL}/api/auth/me`, {
             method: 'GET',
             credentials: 'include',
           });
@@ -102,7 +102,7 @@ const useAuthStore = create<AuthState>()((set, get) => ({
 
       signOut: async () => {
         try {
-          const response = await fetch('/api/auth/signout', {
+          const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL}/api/auth/signout`, {
             method: 'POST',
             credentials: 'include',
           });

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,8 +2,8 @@ import type { AxiosError } from 'axios';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 
-// Vercel Rewrites를 사용하므로 상대 경로 사용
-const API_BASE_URL = '';
+// Backend API base URL
+const API_BASE_URL = process.env.NEXT_PUBLIC_BE_URL || 'https://nurse-backend.duckdns.org';
 
 // 공통 axios 인스턴스 생성
 export const apiClient = axios.create({

--- a/src/store/onboardingStores.ts
+++ b/src/store/onboardingStores.ts
@@ -159,7 +159,7 @@ const useOnboardingStore = create<OnboardingStore>((set, get) => ({
 
       // 서버에서 진행상황 조회
       const response = await fetch(
-        `/api/onboarding/progress?tempUserId=${tempUserId}`,
+        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/progress?tempUserId=${tempUserId}`,
         {
           method: 'GET',
           credentials: 'include',


### PR DESCRIPTION
- Fixed src/lib/axios.ts to use NEXT_PUBLIC_BE_URL
- Restored all authentication API calls to absolute URLs
- Fixed onboarding API endpoints to use absolute paths
- Corrected avatar management API configuration
- Removed broken relative path configuration
- Build tests successfully with no errors

This resolves the 404 errors caused by relative API paths without rewrites.

