### PR TITLE
fix: Replace fetch with apiClient for consistent backend API calls

### DIFF
--- a/src/api/onboarding/useBasicInfoMutation.ts
+++ b/src/api/onboarding/useBasicInfoMutation.ts
@@ -1,6 +1,7 @@
 // src/hooks/useBasicInfoMutation.ts
 import { useMutation } from '@tanstack/react-query';
 import useOnboardingStore from 'src/store/onboardingStores';
+import apiClient from 'src/lib/axios';
 
 interface BasicInfoPayload {
   name: string;
@@ -15,30 +16,19 @@ const useBasicInfoMutation = () => {
   return useMutation({
     mutationFn: async (data: BasicInfoPayload) => {
       // Get tempUserId from store or localStorage
-      const storedTempUserId = tempUserId || 
+      const storedTempUserId = tempUserId ||
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/basic-info`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            ...data,
-            tempUserId: storedTempUserId,
-          }),
-        }
-      );
+      const response = await apiClient.post('/api/onboarding/basic-info', {
+        ...data,
+        tempUserId: storedTempUserId,
+      });
 
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || 'Failed to save basic information');
+      if (!response.data.success) {
+        throw new Error(response.data.message || 'Failed to save basic information');
       }
 
-      return response.json();
+      return response.data;
     },
     onSuccess: () => {
       setStep('employment');

--- a/src/api/onboarding/useCompleteOnboarding.ts
+++ b/src/api/onboarding/useCompleteOnboarding.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import useAuthStore from 'src/hooks/useAuthStore';
 import useOnboardingStore from 'src/store/onboardingStores';
+import apiClient from 'src/lib/axios';
 
 interface CompleteOnboardingResult {
   success: boolean;
@@ -26,31 +27,18 @@ const useCompleteOnboarding = () => {
     setIsLoading(true);
 
     try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/complete`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            tempUserId,
-          }),
-        }
-      );
+      const response = await apiClient.post('/api/onboarding/complete', {
+        tempUserId,
+      });
 
-      if (!response.ok) {
-        const errorData = await response
-          .json()
-          .catch(() => ({ message: 'Failed to complete onboarding' }));
+      if (!response.data.success) {
         const errorMessage =
-          errorData.message || 'Failed to complete onboarding';
+          response.data.message || 'Failed to complete onboarding';
         toast.error(errorMessage);
         throw new Error(errorMessage);
       }
 
-      const result = await response.json();
+      const result = response.data;
 
       // Clear onboarding session data
       localStorage.removeItem('onboarding_session');

--- a/src/api/onboarding/useCultureMutation.ts
+++ b/src/api/onboarding/useCultureMutation.ts
@@ -1,6 +1,7 @@
 // src/api/onboarding/useCultureMutation.ts
 import { useMutation } from '@tanstack/react-query';
 import useOnboardingStore from 'src/store/onboardingStores';
+import apiClient from 'src/lib/axios';
 
 interface CulturePayload {
   unitCulture: number;
@@ -16,30 +17,19 @@ const useCultureMutation = () => {
   return useMutation({
     mutationFn: async (data: CulturePayload) => {
       // Get tempUserId from store or localStorage
-      const storedTempUserId = tempUserId || 
+      const storedTempUserId = tempUserId ||
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/culture`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            ...data,
-            tempUserId: storedTempUserId,
-          }),
-        }
-      );
+      const response = await apiClient.post('/api/onboarding/culture', {
+        ...data,
+        tempUserId: storedTempUserId,
+      });
 
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || 'Failed to save culture information');
+      if (!response.data.success) {
+        throw new Error(response.data.message || 'Failed to save culture information');
       }
 
-      return response.json();
+      return response.data;
     },
     onSuccess: () => {
       setStep('account');

--- a/src/api/onboarding/useEmploymentMutation.ts
+++ b/src/api/onboarding/useEmploymentMutation.ts
@@ -1,6 +1,7 @@
 // src/api/onboarding/useEmploymentMutation.ts
 import { useMutation } from '@tanstack/react-query';
 import useOnboardingStore from 'src/store/onboardingStores';
+import apiClient from 'src/lib/axios';
 
 interface EmploymentPayload {
   specialty: string;
@@ -30,32 +31,21 @@ const useEmploymentMutation = () => {
   return useMutation({
     mutationFn: async (data: EmploymentPayload) => {
       // Get tempUserId from store or localStorage
-      const storedTempUserId = tempUserId || 
+      const storedTempUserId = tempUserId ||
         JSON.parse(localStorage.getItem('onboarding_session') || '{}').tempUserId;
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/employment`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            ...data,
-            tempUserId: storedTempUserId,
-          }),
-        }
-      );
+      const response = await apiClient.post('/api/onboarding/employment', {
+        ...data,
+        tempUserId: storedTempUserId,
+      });
 
-      if (!response.ok) {
-        const error = await response.json();
+      if (!response.data.success) {
         throw new Error(
-          error.message || 'Failed to save employment information'
+          response.data.message || 'Failed to save employment information'
         );
       }
 
-      return response.json();
+      return response.data;
     },
     onSuccess: () => {
       setStep('culture');

--- a/src/api/onboarding/useInitializeOnboarding.ts
+++ b/src/api/onboarding/useInitializeOnboarding.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import useOnboardingStore from 'src/store/onboardingStores';
+import apiClient from 'src/lib/axios';
 
 interface OnboardingSession {
   tempUserId: string;
@@ -20,38 +21,27 @@ interface OnboardingProgress {
 const checkExistingProgress = async (
   tempUserId: string
 ): Promise<OnboardingProgress | null> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/progress/${tempUserId}`,
-    {
-      credentials: 'include',
-    }
-  );
+  try {
+    const response = await apiClient.get(`/api/onboarding/progress/${tempUserId}`);
 
-  if (!response.ok) {
+    if (!response.data.success) {
+      return null;
+    }
+
+    return response.data.data || response.data;
+  } catch {
     return null;
   }
-
-  return response.json();
 };
 
 const createNewOnboarding = async () => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BE_URL}/api/onboarding/init`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify({}),
-    }
-  );
+  const response = await apiClient.post('/api/onboarding/init', {});
 
-  if (!response.ok) {
-    throw new Error('Failed to initialize onboarding.');
+  if (!response.data.success) {
+    throw new Error(response.data.message || 'Failed to initialize onboarding.');
   }
 
-  return response.json();
+  return response.data.data || response.data;
 };
 
 const useInitializeOnboarding = () => {

--- a/src/api/useDifferentialAPI.ts
+++ b/src/api/useDifferentialAPI.ts
@@ -1,6 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-
-const API_BASE_URL = '/api';
+import apiClient from 'src/lib/axios';
 
 // Types
 export interface DifferentialItem {
@@ -52,41 +51,32 @@ export interface DifferentialTypes {
 
 // API functions
 async function fetchDifferentialTypes(): Promise<DifferentialTypes> {
-  const response = await fetch(`${API_BASE_URL}/differentials/types`, {
-    credentials: 'include',
-  });
+  const { data } = await apiClient.get('/api/differentials/types');
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch differential types');
+  if (!data.success) {
+    throw new Error(data.message || 'Failed to fetch differential types');
   }
 
-  const data = await response.json();
   return data.data;
 }
 
 async function fetchAllDifferentialConfigs(): Promise<Record<string, DifferentialConfig>> {
-  const response = await fetch(`${API_BASE_URL}/differentials/config`, {
-    credentials: 'include',
-  });
+  const { data } = await apiClient.get('/api/differentials/config');
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch differential configs');
+  if (!data.success) {
+    throw new Error(data.message || 'Failed to fetch differential configs');
   }
 
-  const data = await response.json();
   return data.data;
 }
 
 async function fetchDifferentialConfig(type: string): Promise<DifferentialConfig> {
-  const response = await fetch(`${API_BASE_URL}/differentials/config/${type}`, {
-    credentials: 'include',
-  });
+  const { data } = await apiClient.get(`/api/differentials/config/${type}`);
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch config for ${type}`);
+  if (!data.success) {
+    throw new Error(data.message || `Failed to fetch config for ${type}`);
   }
 
-  const data = await response.json();
   return data.data;
 }
 
@@ -95,24 +85,12 @@ async function previewDifferentialCalculation(
   basePay: number,
   basePayUnit: string = 'hourly'
 ): Promise<DifferentialCalculationResult> {
-  const response = await fetch(`${API_BASE_URL}/differentials/preview`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    credentials: 'include',
-    body: JSON.stringify({
-      differentials,
-      basePay,
-      basePayUnit,
-    }),
+  const { data } = await apiClient.post('/api/differentials/preview', {
+    differentials,
+    basePay,
+    basePayUnit,
   });
 
-  if (!response.ok) {
-    throw new Error('Failed to preview differential calculation');
-  }
-
-  const data = await response.json();
   if (!data.success) {
     throw new Error(data.message || 'Calculation failed');
   }
@@ -126,25 +104,13 @@ async function calculateAndSaveDifferentials(
   basePay: number,
   basePayUnit: string = 'hourly'
 ): Promise<DifferentialCalculationResult> {
-  const response = await fetch(`${API_BASE_URL}/differentials/calculate`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    credentials: 'include',
-    body: JSON.stringify({
-      jobId,
-      differentials,
-      basePay,
-      basePayUnit,
-    }),
+  const { data } = await apiClient.post('/api/differentials/calculate', {
+    jobId,
+    differentials,
+    basePay,
+    basePayUnit,
   });
 
-  if (!response.ok) {
-    throw new Error('Failed to calculate and save differentials');
-  }
-
-  const data = await response.json();
   if (!data.success) {
     throw new Error(data.message || 'Calculation failed');
   }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { LoadingState } from 'src/components/ui/feedback';
 // import useAuthStore from 'src/hooks/useAuthStore';
+// import apiClient from 'src/lib/axios';
 
 export default function AuthCallback() {
   const router = useRouter();
@@ -28,21 +29,14 @@ export default function AuthCallback() {
 
         if (session) {
           // Sync with backend to create/update user in local database
-          const response = await fetch('/api/auth/oauth/callback', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            credentials: 'include',
-            body: JSON.stringify({
-              access_token: session.access_token,
-              refresh_token: session.refresh_token,
-              user: session.user,
-            }),
+          const response = await apiClient.post('/api/auth/oauth/callback', {
+            access_token: session.access_token,
+            refresh_token: session.refresh_token,
+            user: session.user,
           });
 
-          if (response.ok) {
-            const userData = await response.json();
+          if (response.data.success) {
+            const userData = response.data.data || response.data;
             
             // Update auth store
             useAuthStore.getState().setUser({


### PR DESCRIPTION
- Updated useDifferentialAPI.ts to use apiClient instead of fetch
- Fixed all onboarding API files to use apiClient for proper backend URL resolution
- Updated auth callback page to use apiClient (in commented code for future use)

This fixes the issue where API calls were being sent to the frontend domain (nursing-project.vercel.app) instead of the backend (nurse-backend.duckdns.org)
